### PR TITLE
docs(release): gate upstream-PR review through workspace /zenodotus skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ groups/global/*
 .nanoclaw/
 
 agents-sdk-docs
+.zenodotus/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# NanoClaw — Agent Policy
+
+## GitHub
+
+- **Owner:** Kromatic-Innovation (this fork)
+- **Repo:** nanoclaw
+- **Upstream:** [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw)
+
+This repo is the Kromatic-Innovation fork of NanoClaw. Skill updates and
+feature work originate here; selected changes flow upstream to
+`qwibitai/nanoclaw` via PR.
+
+## Branch policy
+
+- Default branch: `main`
+- Skill PRs to upstream live on `feature/<skill>` branches per the
+  `contribute-to-nanoclaw` workspace skill
+- Upstream sync via `sync/upstream-main` branches
+
+## Pre-upstream-PR review gate
+
+Before opening any PR from this fork to `qwibitai/nanoclaw`, run the
+workspace `/zenodotus` skill against the change scope:
+
+```
+/zenodotus --repo . --ref <feature-branch> --version <target-version> \
+  --prior-tag <upstream-base> --personas drive-by-contributor
+```
+
+The **drive-by-contributor** persona is the critical lens here: the
+upstream maintainer will read your PR as a stranger. Run that persona
+specifically. Add `production-evaluator` and `maintainers-maintainer` for
+broader skill releases.
+
+Zenodotus reviewers operate under **no-context isolation** — they see only
+the public surface (README, CHANGELOG, CONTRIBUTING, public API, tests,
+release diff) and **nothing else**. No `AGENTS.md`, no `CLAUDE.md`, no
+`.claude/`, no internal docs, no commit history outside the diff window.
+This mirrors what the upstream maintainer sees.
+
+Verdict gates the PR:
+
+- **Pass** → open the upstream PR using the drafted summary from
+  `.zenodotus/<version>/tag-message.md` as the PR body.
+- **Conditional** / **Fail** → fix the must-fix items on the feature
+  branch, re-run `/zenodotus`, retry.
+
+Zenodotus is **additive** to internal review, not a substitute. Workspace
+PR [Kromatic-Innovation/code-workspace-config#264](https://github.com/Kromatic-Innovation/code-workspace-config/pull/264)
+tracks the skill itself; issue
+[Kromatic-Innovation/code-workspace-config#234](https://github.com/Kromatic-Innovation/code-workspace-config/issues/234)
+captures the policy rationale.
+
+The `.zenodotus/` directory is gitignored — verdict artifacts are local
+record, not durable repo state.
+
+## Related workspace skills
+
+- `/zenodotus` — the no-context review gate above
+- `/contribute-to-nanoclaw` — the upstream PR convention (branch shape,
+  SKILL.md format, downstream-patches-local rule)
+
+## Repo conventions
+
+See `CLAUDE.md` for the durable architectural notes (orchestrator, channel
+registry, IPC, OneCLI secrets, container layout). This file (`AGENTS.md`)
+covers process policy only.


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` to the Kromatic-Innovation fork of NanoClaw citing the workspace `/zenodotus` skill (workspace PR [Kromatic-Innovation/code-workspace-config#264](https://github.com/Kromatic-Innovation/code-workspace-config/pull/264), tracking [Kromatic-Innovation/code-workspace-config#234](https://github.com/Kromatic-Innovation/code-workspace-config/issues/234)) as the required gate before opening any PR from this fork to `qwibitai/nanoclaw`.

For nanoclaw the critical lens is **drive-by-contributor** — the upstream maintainer reads incoming PRs as a stranger. Zenodotus enforces that isolation explicitly: reviewers see only the public surface (README, CHANGELOG, CONTRIBUTING, public API, tests, release diff) and **nothing else**. No `AGENTS.md`, no `CLAUDE.md`, no internal docs, no commit history outside the diff window.

Also gitignores `.zenodotus/` — verdict artifacts are local record, not durable repo state.

## Test plan

- [x] AGENTS.md created
- [x] `.gitignore` updated for `.zenodotus/`
- [ ] First exercise: next upstream skill PR runs through `/zenodotus --personas drive-by-contributor` before opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)
